### PR TITLE
Fix download callback function

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ func main() {
 	csvURL := fmt.Sprintf("https://global.americanexpress.com/api/servicing/v1/financials/documents?file_format=csv&limit=3&status=posted&account_key=%s&client_id=AmexAPI", accountKey)
 
 	download, err := page.ExpectDownload(func() error {
-		_, err := page.Goto(csvURL)
-		return err
+		page.Goto(csvURL)
+		return nil
 	})
 
 	if err != nil {


### PR DESCRIPTION
We don't need to return errors from `page.Goto()`. Returning them causes unexpected waiting behavior.
